### PR TITLE
fix bug that caused game to end as tie, even if player should win on …

### DIFF
--- a/tictactoe/7/script.js
+++ b/tictactoe/7/script.js
@@ -28,7 +28,7 @@ function startGame() {
 function turnClick(square) {
 	if (typeof origBoard[square.target.id] == 'number') {
 		turn(square.target.id, huPlayer)
-		if (!checkTie()) turn(bestSpot(), aiPlayer);
+		if (!checkWin(origBoard, huPlayer) && !checkTie()) turn(bestSpot(), aiPlayer);
 	}
 }
 


### PR DESCRIPTION
Hi Beau, thanks so much for the video going through the Tic Tac Toe game using minimax. I noticed a bug in the code, and made a comment on how to fix it in the comments section of the video. I thought I would make a pull request here with the fix too.

This pull request fixes a bug that was in the `turnClick` function that would happen if the human player should win on the last move.

Before this, if the player should win on the last move, the game ends as a tie because the `checkTie` function would say that there was no more empty squares when the AI player went to make a move, but the AI player shouldn't move in that case as the game is already won by the human player.

With this change, if the humanPlayer wins with the last move, the `checkWin` function will return `true`, so the line `if (!checkWin(origBoard, huPlayer) && !checkTie()) turn(bestSpot(), aiPlayer);` will not get return false and the `turn(bestSpot(), aiPlayer)` will not be executed. This means that the AI player will not make a move, and the player will win.