### PR TITLE
remove param passed into emptySqares()

### DIFF
--- a/tictactoe/7/script.js
+++ b/tictactoe/7/script.js
@@ -89,7 +89,7 @@ function checkTie() {
 }
 
 function minimax(newBoard, player) {
-	var availSpots = emptySquares(newBoard);
+	var availSpots = emptySquares();
 
 	if (checkWin(newBoard, huPlayer)) {
 		return {score: -10};


### PR DESCRIPTION
No need to pass param to emptySqures() as it returns availableSpots from origBoard which is a global variable.