### PR TITLE
changing bootstrap link to v3.7 for game of life to resolve dropdown …

### DIFF
--- a/gameoflife/public/index.html
+++ b/gameoflife/public/index.html
@@ -11,7 +11,7 @@
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
 
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/latest/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.


### PR DESCRIPTION
…issue

Bootstrap dropdown menu doesn't function with the current v4 of bootstrap, changed the style sheet link to be fixed to a Bootstrap v3.7 to resolve